### PR TITLE
Wire up code-to-cloud Fleet deployment

### DIFF
--- a/demo-gitrepo.yml
+++ b/demo-gitrepo.yml
@@ -1,0 +1,17 @@
+apiVersion: fleet.cattle.io/v1alpha1
+kind: GitRepo
+metadata:
+  name: from-code-to-cloud
+  namespace: fleet-default
+  labels:
+    app: from-code-to-cloud
+    type: demo
+spec:
+  repo: https://github.com/jmcglock/fleet-demo
+  branch: main
+  paths:
+  - demo
+  forceSyncGeneration: 1
+  insecureBranch: false
+  timeout: 300
+  pollingInterval: 60

--- a/demo/deployment.yml
+++ b/demo/deployment.yml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: from-code-to-cloud
+  namespace: from-code-to-cloud
+  labels:
+    app: from-code-to-cloud
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: from-code-to-cloud
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  template:
+    metadata:
+      name: from-code-to-cloud
+      labels:
+        app: from-code-to-cloud
+    spec:
+      containers:
+      - name: from-code-to-cloud
+        image: ghcr.io/jmcglock/from-code-to-cloud:latest
+        env:
+        - name: TZ
+          value: "America/New_York"
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 80
+        resources:
+          limits:
+            cpu: "500m"
+            memory: "512Mi"
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 5

--- a/demo/fleet.yml
+++ b/demo/fleet.yml
@@ -1,2 +1,5 @@
 defaultNamespace: from-code-to-cloud
 namespace: from-code-to-cloud
+
+dependsOn:
+  - name: traefik-traefik

--- a/demo/ingress.yml
+++ b/demo/ingress.yml
@@ -1,0 +1,14 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: from-code-to-cloud-ingressroute
+  namespace: from-code-to-cloud
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: Host(`demo.jmcglock.com`)
+      kind: Rule
+      services:
+        - name: from-code-to-cloud-svc
+          port: 80

--- a/demo/service.yml
+++ b/demo/service.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: from-code-to-cloud-svc
+  namespace: from-code-to-cloud
+spec:
+  selector:
+    app: from-code-to-cloud
+  ports:
+  - name: from-code-to-cloud
+    port: 80
+    protocol: TCP
+    targetPort: 80


### PR DESCRIPTION
## Summary
- `demo/deployment.yml` — Deploys `ghcr.io/jmcglock/from-code-to-cloud:latest`
- `demo/service.yml` — ClusterIP service on port 80
- `demo/ingress.yml` — Traefik IngressRoute for `demo.jmcglock.com`
- `demo/fleet.yml` — Updated with `dependsOn: traefik-traefik` so Traefik deploys first
- `demo-gitrepo.yml` — GitRepo resource to apply to the cluster to activate Fleet sync

## To activate
```bash
kubectl apply -f demo-gitrepo.yml
```